### PR TITLE
Nodeport

### DIFF
--- a/charts/pulsar/templates/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana-service.yaml
@@ -36,9 +36,7 @@ spec:
     - name: server
       port: {{ .Values.grafana.service.port }}
       targetPort: {{ .Values.grafana.service.targetPort }}
-      {{- if and .Values.grafana.service.nodePort }}
       nodePort: {{ .Values.grafana.service.nodePort }}
-      {{- end }}
       protocol: TCP
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/templates/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana-service.yaml
@@ -36,6 +36,9 @@ spec:
     - name: server
       port: {{ .Values.grafana.service.port }}
       targetPort: {{ .Values.grafana.service.targetPort }}
+      {{- if eq .Values.grafana.service.type "NodePort" }}
+      nodePort: {{ .Values.grafana.ports.nodePort }}
+      {{- end }}
       protocol: TCP
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/templates/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana-service.yaml
@@ -36,8 +36,8 @@ spec:
     - name: server
       port: {{ .Values.grafana.service.port }}
       targetPort: {{ .Values.grafana.service.targetPort }}
-      {{- if eq .Values.grafana.service.type "NodePort" }}
-      nodePort: {{ .Values.grafana.ports.nodePort }}
+      {{- if and .Values.grafana.service.nodePort }}
+      nodePort: {{ .Values.grafana.service.nodePort }}
       {{- end }}
       protocol: TCP
   selector:

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -37,29 +37,21 @@ spec:
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
-      {{- if .Values.proxy.ports.httpNodePort }}
       nodePort: {{ .Values.proxy.ports.httpNodePort }}
-      {{- end }}
     - name: pulsar
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
-      {{- if .Values.proxy.ports.pulsarNodePort }}
       nodePort: {{ .Values.proxy.ports.pulsarNodePort }}
-      {{- end }}
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
-      {{- if .Values.proxy.ports.httpsNodePort }}
       nodePort: {{ .Values.proxy.ports.httpsNodePort }}
-      {{- end }}
     - name: pulsarssl
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
-      {{- if .Values.proxy.ports.pulsarsslNodePort }}
       nodePort: {{ .Values.proxy.ports.pulsarsslNodePort }}
-      {{- end }}
     {{- end }}
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -33,21 +33,33 @@ metadata:
 spec:
   type: {{ .Values.proxy.service.type }}
   ports:
-    {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
+    {{- if and .Values.plain.enabled .Values.plain.proxy.enabled }}
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.ports.httpNodePort }}
+      {{- end }}
     - name: pulsar
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.ports.pulsarNodePort }}
+      {{- end }}
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.ports.httpsNodePort }}
+      {{- end }}
     - name: pulsarssl
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.ports.pulsarsslNodePort }}
+      {{- end }}
     {{- end }}
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -37,13 +37,13 @@ spec:
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
-      {{- if eq .Values.proxy.service.type "NodePort" }}
+      {{- if .Values.proxy.ports.httpNodePort }}
       nodePort: {{ .Values.proxy.ports.httpNodePort }}
       {{- end }}
     - name: pulsar
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
-      {{- if eq .Values.proxy.service.type "NodePort" }}
+      {{- if .Values.proxy.ports.pulsarNodePort }}
       nodePort: {{ .Values.proxy.ports.pulsarNodePort }}
       {{- end }}
     {{- end }}
@@ -51,13 +51,13 @@ spec:
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
-      {{- if eq .Values.proxy.service.type "NodePort" }}
+      {{- if .Values.proxy.ports.httpsNodePort }}
       nodePort: {{ .Values.proxy.ports.httpsNodePort }}
       {{- end }}
     - name: pulsarssl
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
-      {{- if eq .Values.proxy.service.type "NodePort" }}
+      {{- if .Values.proxy.ports.pulsarsslNodePort }}
       nodePort: {{ .Values.proxy.ports.pulsarsslNodePort }}
       {{- end }}
     {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -34,8 +34,8 @@ spec:
     - name: server
       port: {{ .Values.pulsar_manager.service.port }}
       targetPort: {{ .Values.pulsar_manager.service.targetPort }}
-      {{- if eq .Values.pulsar_manager.service.type "NodePort" }}
-      nodePort: {{ .Values.pulsar_manager.ports.nodePort }}
+      {{- if .Values.pulsar_manager.service.nodePort }}
+      nodePort: {{ .Values.pulsar_manager.service.nodePort }}
       {{- end }}
       protocol: TCP
   selector:

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -34,9 +34,7 @@ spec:
     - name: server
       port: {{ .Values.pulsar_manager.service.port }}
       targetPort: {{ .Values.pulsar_manager.service.targetPort }}
-      {{- if .Values.pulsar_manager.service.nodePort }}
       nodePort: {{ .Values.pulsar_manager.service.nodePort }}
-      {{- end }}
       protocol: TCP
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -34,6 +34,9 @@ spec:
     - name: server
       port: {{ .Values.pulsar_manager.service.port }}
       targetPort: {{ .Values.pulsar_manager.service.targetPort }}
+      {{- if eq .Values.pulsar_manager.service.type "NodePort" }}
+      nodePort: {{ .Values.pulsar_manager.ports.nodePort }}
+      {{- end }}
       protocol: TCP
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -761,10 +761,10 @@ proxy:
     https: 443
     pulsar: 6650
     pulsarssl: 6651
-    httpNodePort: 31010
-    httpsNodePort: 31011
-    pulsarNodePort: 31000
-    pulsarsslNodePort: 31001
+    httpNodePort: 
+    httpsNodePort: 
+    pulsarNodePort: 
+    pulsarsslNodePort: 
   service:
     annotations: {}
     type: LoadBalancer
@@ -934,7 +934,7 @@ grafana:
     type: LoadBalancer
     port: 3000
     targetPort: 3000
-    nodePort: 31030
+    nodePort: 
     annotations: {}
   plugins: []
   ## Grafana configMap
@@ -997,7 +997,7 @@ pulsar_manager:
     type: LoadBalancer
     port: 9527
     targetPort: 9527
-    nodePort: 31020
+    nodePort: 
     annotations: {}
   ## Pulsar manager ingress
   ## templates/pulsar-manager-ingress.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -934,6 +934,7 @@ grafana:
     type: LoadBalancer
     port: 3000
     targetPort: 3000
+    nodePort: 31030
     annotations: {}
   plugins: []
   ## Grafana configMap
@@ -996,6 +997,7 @@ pulsar_manager:
     type: LoadBalancer
     port: 9527
     targetPort: 9527
+    nodePort: 31020
     annotations: {}
   ## Pulsar manager ingress
   ## templates/pulsar-manager-ingress.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -225,6 +225,12 @@ tls:
   toolset:
     cert_name: tls-toolset
 
+# Enable non-encrypted proxy connections together with TLS
+plain:
+  enabled: true
+  proxy:
+    enabled: true
+
 # Enable or disable broker authentication and authorization.
 auth:
   authentication:
@@ -755,6 +761,10 @@ proxy:
     https: 443
     pulsar: 6650
     pulsarssl: 6651
+    httpNodePort: 31010
+    httpsNodePort: 31011
+    pulsarNodePort: 31000
+    pulsarsslNodePort: 31001
   service:
     annotations: {}
     type: LoadBalancer

--- a/examples/values-minikube-nodeport.yaml
+++ b/examples/values-minikube-nodeport.yaml
@@ -48,8 +48,13 @@ broker:
 
 proxy:
   replicaCount: 1
-  ports:
-    httpNodePort: 31010
-    pulsarNodePort: 31000
+  service:
+    type: NodePort
+
+grafana:
+  service:
+    type: NodePort
+
+pulsar_manager:
   service:
     type: NodePort

--- a/examples/values-minikube-nodeport.yaml
+++ b/examples/values-minikube-nodeport.yaml
@@ -48,13 +48,16 @@ broker:
 
 proxy:
   replicaCount: 1
-  service:
-    type: NodePort
+  ports:
+    httpNodePort: 31010
+    httpsNodePort: 31011
+    pulsarNodePort: 31000
+    pulsarsslNodePort: 31001
 
 grafana:
   service:
-    type: NodePort
+    nodePort: 31030
 
 pulsar_manager:
   service:
-    type: NodePort
+    nodePort: 31020

--- a/examples/values-minikube-nodeport.yaml
+++ b/examples/values-minikube-nodeport.yaml
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## deployed withh emptyDir
+volumes:
+  persistence: false
+
+# disabled AntiAffinity
+affinity:
+  anti_affinity: false
+
+# disable auto recovery
+components:
+  autorecovery: false
+
+zookeeper:
+  replicaCount: 1
+
+bookkeeper:
+  replicaCount: 1
+
+broker:
+  replicaCount: 1
+  configData:
+    ## Enable `autoSkipNonRecoverableData` since bookkeeper is running
+    ## without persistence
+    autoSkipNonRecoverableData: "true"
+    # storage settings
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
+
+proxy:
+  replicaCount: 1
+  ports:
+    httpNodePort: 31010
+    pulsarNodePort: 31000
+  service:
+    type: NodePort


### PR DESCRIPTION
Add support to specify NodePort

### Motivation

Set node ports to be able to deploy Pulsar in a k8s cluster without a loadbalancer.


