### PR TITLE
Add possibility to set nodeport for the Loadbalancer services

### DIFF
--- a/charts/pulsar/templates/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana-service.yaml
@@ -36,6 +36,7 @@ spec:
     - name: server
       port: {{ .Values.grafana.service.port }}
       targetPort: {{ .Values.grafana.service.targetPort }}
+      nodePort: {{ .Values.grafana.service.nodePort }}
       protocol: TCP
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -33,21 +33,25 @@ metadata:
 spec:
   type: {{ .Values.proxy.service.type }}
   ports:
-    {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
+    {{- if and .Values.plain.enabled .Values.plain.proxy.enabled }}
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
+      nodePort: {{ .Values.proxy.ports.httpNodePort }}
     - name: pulsar
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
+      nodePort: {{ .Values.proxy.ports.pulsarNodePort }}
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
+      nodePort: {{ .Values.proxy.ports.httpsNodePort }}
     - name: pulsarssl
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
+      nodePort: {{ .Values.proxy.ports.pulsarsslNodePort }}
     {{- end }}
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -34,6 +34,7 @@ spec:
     - name: server
       port: {{ .Values.pulsar_manager.service.port }}
       targetPort: {{ .Values.pulsar_manager.service.targetPort }}
+      nodePort: {{ .Values.pulsar_manager.service.nodePort }}
       protocol: TCP
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -225,6 +225,12 @@ tls:
   toolset:
     cert_name: tls-toolset
 
+# Enable non-encrypted proxy connections together with TLS
+plain:
+  enabled: true
+  proxy:
+    enabled: true
+
 # Enable or disable broker authentication and authorization.
 auth:
   authentication:
@@ -755,6 +761,10 @@ proxy:
     https: 443
     pulsar: 6650
     pulsarssl: 6651
+    httpNodePort: 
+    httpsNodePort: 
+    pulsarNodePort: 
+    pulsarsslNodePort: 
   service:
     annotations: {}
     type: LoadBalancer
@@ -924,6 +934,7 @@ grafana:
     type: LoadBalancer
     port: 3000
     targetPort: 3000
+    nodePort: 
     annotations: {}
   plugins: []
   ## Grafana configMap
@@ -986,6 +997,7 @@ pulsar_manager:
     type: LoadBalancer
     port: 9527
     targetPort: 9527
+    nodePort: 
     annotations: {}
   ## Pulsar manager ingress
   ## templates/pulsar-manager-ingress.yaml

--- a/examples/values-minikube-nodeport.yaml
+++ b/examples/values-minikube-nodeport.yaml
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## deployed withh emptyDir
+volumes:
+  persistence: false
+
+# disabled AntiAffinity
+affinity:
+  anti_affinity: false
+
+# disable auto recovery
+components:
+  autorecovery: false
+
+zookeeper:
+  replicaCount: 1
+
+bookkeeper:
+  replicaCount: 1
+
+broker:
+  replicaCount: 1
+  configData:
+    ## Enable `autoSkipNonRecoverableData` since bookkeeper is running
+    ## without persistence
+    autoSkipNonRecoverableData: "true"
+    # storage settings
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
+
+proxy:
+  replicaCount: 1
+  ports:
+    httpNodePort: 31010
+    httpsNodePort: 31011
+    pulsarNodePort: 31000
+    pulsarsslNodePort: 31001
+
+grafana:
+  service:
+    nodePort: 31030
+
+pulsar_manager:
+  service:
+    nodePort: 31020


### PR DESCRIPTION
Add support to specify NodePort.
Allow plain text and TLS encrypted communication at the same time.

### Motivation

Set node ports to be able to deploy Pulsar in a k8s cluster with fixed ports without a loadbalancer.
Allow both plain text and TLS to support migration fom plain text to TLS before closing the plain text ports.