### PR TITLE
Upgrade to cert-manager v1.3.0 and apiVersion cert-manager.io/v1

### DIFF
--- a/charts/pulsar/templates/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls-certs-internal.yaml
@@ -31,15 +31,14 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.algorithm }}
+    encoding: {{ .Values.tls.common.encoding }}
   usages:
     - server auth
     - client auth
@@ -73,15 +72,14 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.algorithm }}
+    encoding: {{ .Values.tls.common.encoding }}
   usages:
     - server auth
     - client auth
@@ -115,15 +113,14 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.algorithm }}
+    encoding: {{ .Values.tls.common.encoding }}
   usages:
     - server auth
     - client auth
@@ -156,15 +153,14 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.algorithm }}
+    encoding: {{ .Values.tls.common.encoding }}
   usages:
     - server auth
     - client auth
@@ -194,15 +190,14 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.algorithm }}
+    encoding: {{ .Values.tls.common.encoding }}
   usages:
     - server auth
     - client auth
@@ -232,15 +227,14 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.algorithm }}
+    encoding: {{ .Values.tls.common.encoding }}
   usages:
     - server auth
     - client auth

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -200,8 +200,8 @@ tls:
     organization:
       - pulsar
     keySize: 4096
-    keyAlgorithm: rsa
-    keyEncoding: pkcs8
+    algorithm: RSA
+    encoding: PKCS8
   # settings for generating certs for proxy
   proxy:
     enabled: false

--- a/examples/values-tls.yaml
+++ b/examples/values-tls.yaml
@@ -30,5 +30,6 @@ tls:
 # issue selfsigning certs
 certs:
   internal_issuer:
+    apiVersion: cert-manager.io/v1
     enabled: true
     type: selfsigning

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -21,11 +21,7 @@
 
 NAMESPACE=cert-manager
 NAME=cert-manager
-VERSION=v0.13.0
-
-# Install cert-manager CustomResourceDefinition resources
-echo "Installing cert-manager CRD resources ..."
-kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/${VERSION}/deploy/manifests/00-crds.yaml
+VERSION=v1.3.0
 
 # Create the namespace 
 kubectl get ns ${NAMESPACE}
@@ -50,6 +46,7 @@ echo "Installing cert-manager ${VERSION} to namespace ${NAMESPACE} as '${NAME}' 
 helm install \
   --namespace ${NAMESPACE} \
   --version ${VERSION} \
+  --set installCRDs=true \
   ${NAME} \
   jetstack/cert-manager
 echo "Successfully installed cert-manager ${VERSION}."


### PR DESCRIPTION
Upgrade cert-manager to v1.3.0

### Motivation

The cert-manager api has been changes since v1. This upgrade allows the installation of the latest cert-manager.
